### PR TITLE
Ngrok 1 hack

### DIFF
--- a/src/ngrok/server/control.go
+++ b/src/ngrok/server/control.go
@@ -148,7 +148,7 @@ func (c *Control) registerTunnel(rawTunnelReq *msg.ReqTunnel) {
 
 		// acknowledge success
 		c.out <- &msg.NewTunnel{
-			Url:      t.url,
+			Url:      strings.Replace(t.url, opts.domain, "ngrok.com", 1),
 			Protocol: proto,
 			ReqId:    rawTunnelReq.ReqId,
 		}

--- a/src/ngrok/server/tunnel.go
+++ b/src/ngrok/server/tunnel.go
@@ -267,7 +267,7 @@ func (t *Tunnel) HandlePublicConnection(publicConn conn.Conn) {
 
 		// tell the client we're going to start using this proxy connection
 		startPxyMsg := &msg.StartProxy{
-			Url:        t.url,
+			Url:        strings.Replace(t.url, opts.domain, "ngrok.com", 1),
 			ClientAddr: publicConn.RemoteAddr().String(),
 		}
 


### PR DESCRIPTION
Hack around [ngrok's](https://www.npmjs.com/package/ngrok) stdout parsing of ngrok public url by always returning uuid.ngrok.com addresses from ngrokd.
